### PR TITLE
README: Fixing Code Block

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Sinope thermostats run along with a web application called neviweb which is basi
 
 homebridge-sinope uses these web api so that you can interact with siri as an alternative to neviweb.
 
-```Notes: This is still a beta version.
+`Notes: This is still a beta version.`
 
 ```Todos: Add lint, tests, refactor
 
@@ -16,4 +16,4 @@ Improvements:
 - Instead of login every time on the neviweb platform when extracting handling
 characteristic, we should reuse the session-id by pinging the gateway.
 If there is a 200 response, reuse the session-id, otherwise retry login.
-- Mecanism to use the same device object for all it's characteristic.
+- Mecanism to use the same device object for all it's characteristic.```


### PR DESCRIPTION
One line (`Notes: This is still a beta version.`) was being hidden by an open code block that was not closed.